### PR TITLE
Schedule-based transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # StateMachine
 A State Machine library for Arduino based on [rppelayo's finite state machine library](https://github.com/rppelayo/FiniteStateMachine?tab=readme-ov-file). Provides usage of both Finite State Machines (FSM) and Hierarchical State Machines (HSM).
 
+see examples on how to use the library.
+
 ### Configuration
-- `MAX_STACK_DEPTH`: sets the maximum stack depth for the HSM (required for traversing states from top-down manner). Default is 10.
+- `FSM_TRANSITION_STACK_SIZE`: controls how many transitions can be staged on the FSM. Default is 10.
+- `HSM_TRANSITION_STACK_SIZE`: controls how many transitions can be staged on the HSM. Default is 30.
+- `HSM_STACK_DEPTH`: sets the stack depth for the HSM (required for traversing states in top-down manner). Default is 10.
 - Always call transitionTo at `begin` function to initialize the entry point of your state machine.
 
 ### Limitations

--- a/examples/FSM/FooContext.hpp
+++ b/examples/FSM/FooContext.hpp
@@ -4,9 +4,9 @@
 
 struct FooContext
 {
-    static FSM<FooContext>::State const sOff;
-    static FSM<FooContext>::State const sRun;
-    static FSM<FooContext>::State const sCooldown;
+    static FSM<FooContext>::State sOff;
+    static FSM<FooContext>::State sRun;
+    static FSM<FooContext>::State sCooldown;
 
     uint8_t count;
     uint8_t elapsed;

--- a/examples/FSM/States/CooldownState.cpp
+++ b/examples/FSM/States/CooldownState.cpp
@@ -8,10 +8,10 @@ static void enter(FooContext* const ctx)
 
 static void update(FooContext* const ctx)
 {
-    if (digitalRead(4, LOW))
+    if (digitalRead(4) == LOW)
         ctx->fsm->transitionTo(FooContext::sOff);
-    else if (millis() - elapsed >= 5000)
+    else if (millis() - ctx->elapsed >= 5000)
         ctx->fsm->transitionTo(FooContext::sRun);
 }
 
-FSM<FooContext>::State const FooContext::sCooldown(enter, update, nullptr);
+FSM<FooContext>::State FooContext::sCooldown(enter, update, nullptr);

--- a/examples/FSM/States/OffState.cpp
+++ b/examples/FSM/States/OffState.cpp
@@ -8,8 +8,8 @@ static void enter(FooContext* const ctx)
 
 static void update(FooContext* const ctx)
 {
-    if (digitalRead(4, HIGH))
+    if (digitalRead(4) == HIGH)
         ctx->fsm->transitionTo(FooContext::sRun);
 }
 
-FSM<FooContext>::State const FooContext::sOff(enter, update, nullptr);
+FSM<FooContext>::State FooContext::sOff(enter, update, nullptr);

--- a/examples/FSM/States/RunState.cpp
+++ b/examples/FSM/States/RunState.cpp
@@ -16,10 +16,10 @@ static void update(FooContext* const ctx)
         ctx->count++;
     }
 
-    if (digitalRead(4, LOW))
+    if (digitalRead(4) == LOW)
         ctx->fsm->transitionTo(FooContext::sOff);
-    else if (ctx->count == 5)
+    else if (((ctx->count + 1) % 6) == 0)
         ctx->fsm->transitionTo(FooContext::sCooldown);
 }
 
-FSM<FooContext>::State const FooContext::sRun(enter, update, nullptr);
+FSM<FooContext>::State FooContext::sRun(enter, update, nullptr);

--- a/examples/HSM/FooContext.hpp
+++ b/examples/HSM/FooContext.hpp
@@ -4,10 +4,10 @@
 
 struct FooContext
 {
-    HSM<FooContext>::State const sOff;
-    HSM<FooContext>::State const sOnGroup;
-    HSM<FooContext>::State const sRun;
-    HSM<FooContext>::State const sCooldown;
+    static HSM<FooContext>::State sOff;
+    static HSM<FooContext>::State sOnGroup;
+    static HSM<FooContext>::State sRun;
+    static HSM<FooContext>::State sCooldown;
 
     uint8_t count;
     uint8_t current;

--- a/examples/HSM/States/CooldownState.cpp
+++ b/examples/HSM/States/CooldownState.cpp
@@ -6,4 +6,4 @@ static void update(FooContext* const ctx)
         ctx->hsm->transitionTo(FooContext::sRun);
 }
 
-HSM<FooContext>::State const FooContext::sCooldown(&FooContext::sOnGroup, nullptr, update, nullptr);
+HSM<FooContext>::State FooContext::sCooldown(&FooContext::sOnGroup, nullptr, update, nullptr);

--- a/examples/HSM/States/OffState.cpp
+++ b/examples/HSM/States/OffState.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#include "States/FooContext.hpp"
+#include "FooContext.hpp"
 
 static void enter(FooContext* const ctx)
 {

--- a/examples/HSM/States/OffState.cpp
+++ b/examples/HSM/States/OffState.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#include "FooContext.hpp"
+#include "States/FooContext.hpp"
 
 static void enter(FooContext* const ctx)
 {
@@ -8,8 +8,8 @@ static void enter(FooContext* const ctx)
 
 static void update(FooContext* const ctx)
 {
-    if (digitalRead(4, HIGH))
+    if (digitalRead(4) == HIGH)
         ctx->hsm->transitionTo(FooContext::sOnGroup);
 }
 
-HSM<FooContext>::State const FooContext::sOff(nullptr, enter, update, nullptr);
+HSM<FooContext>::State FooContext::sOff(nullptr, enter, update, nullptr);

--- a/examples/HSM/States/OnGroupState.cpp
+++ b/examples/HSM/States/OnGroupState.cpp
@@ -10,8 +10,8 @@ static void update(FooContext* const ctx)
 {
     ctx->current = millis();
     
-    if (digitalRead(4, LOW))
+    if (digitalRead(4) == LOW)
         ctx->hsm->transitionTo(FooContext::sOff);
 }
 
-HSM<FooContext>::State const FooContext::sOnGroup(nullptr, enter, update, nullptr);
+HSM<FooContext>::State FooContext::sOnGroup(nullptr, enter, update, nullptr);

--- a/examples/HSM/States/RunState.cpp
+++ b/examples/HSM/States/RunState.cpp
@@ -13,8 +13,8 @@ static void update(FooContext* const ctx)
         ctx->count++;
     }
 
-    if (ctx->count == 5)
+    if (((ctx->count +1) % 6) == 0)
         ctx->transitionTo(FooContext::sCooldown);
 }
 
-HSM<FooContext>::State const FooContext::sRun(&FooContext::sOnGroup, enter, update, nullptr);
+HSM<FooContext>::State FooContext::sRun(&FooContext::sOnGroup, enter, update, nullptr);

--- a/src/FiniteStateMachine.hpp
+++ b/src/FiniteStateMachine.hpp
@@ -27,7 +27,7 @@ public:
         return handler.isInState(state);
     }
 
-    void update()
+    void update();
     void transitionTo(State& state, bool immediate = false);
 
 private:

--- a/src/HierarchicalStateMachine.hpp
+++ b/src/HierarchicalStateMachine.hpp
@@ -7,7 +7,7 @@
 #endif
 
 #ifndef HSM_TRANSITION_STACK_SIZE
-#define HSM_TRANSITION_STACK_SIZE (STACK_DEPTH * 3)
+#define HSM_TRANSITION_STACK_SIZE (HSM_STACK_DEPTH * 3)
 #endif
 
 template<class TContext>

--- a/src/StateMachineHandler.hpp
+++ b/src/StateMachineHandler.hpp
@@ -55,7 +55,7 @@ private:
         if (transitionStackTop >= SZ)
             return;
 
-        transition[transitionStackTop++] = { status, &src, dst };
+        transitionStack[transitionStackTop++] = { status, &src, dst };
     }
 
     StateBase<TContext>* currentState;


### PR DESCRIPTION
- updated transition logic
  - makes use of a simple stack array to schedule transitions
  - size can be adjusted by modifying the `FSM_TRANSITION_STACKS_SIZE` and `HSM_TRANSITION_STACK_SIZE` macro
- updated README.md
- fixed example codes