### PR TITLE
Refactor transition data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A State Machine library for Arduino based on [rppelayo's finite state machine li
 see examples on how to use the library.
 
 ### Configuration
-- `FSM_TRANSITION_STACK_SIZE`: controls how many transitions can be staged on the FSM. Default is 10.
-- `HSM_TRANSITION_STACK_SIZE`: controls how many transitions can be staged on the HSM. Default is 30.
 - `HSM_STACK_DEPTH`: sets the stack depth for the HSM (required for traversing states in top-down manner). Default is 10.
 - Always call transitionTo at `begin` function to initialize the entry point of your state machine.
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "StateMachine",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A State Machine library for Arduino that provides usage for Finite State Machines (FSM) and Hierarchical State Machines (HSM).",
     "keywords": "state, machine, finite-state-machine, hierarchical-state-machine, fsm, hsm",
     "repository":

--- a/src/FiniteStateMachine.hpp
+++ b/src/FiniteStateMachine.hpp
@@ -1,10 +1,6 @@
 #pragma once
 #include "StateMachineHandler.hpp"
 
-#ifndef FSM_TRANSITION_STACK_SIZE
-#define FSM_TRANSITION_STACK_SIZE 10
-#endif
-
 template<class TContext>
 class FiniteStateMachine
 {
@@ -31,7 +27,9 @@ public:
     void transitionTo(State& state, bool immediate = false);
 
 private:
-    StateMachineHandler<TContext, FSM_TRANSITION_STACK_SIZE> handler;
+    static constexpr uint8_t QUEUE_SIZE = 4;
+
+    StateMachineHandler<TContext, QUEUE_SIZE + 1> handler;
 };
 
 template<class TContext>
@@ -40,17 +38,18 @@ using FSM = FiniteStateMachine<TContext>;
 template<class TContext>
 void FiniteStateMachine<TContext>::transitionTo(FiniteStateMachine<TContext>::State& state, bool immediate)
 {
-    handler.clearStagedTransitions();
-    
-    handler.stageTransition(&state);
-    
-    handler.stageTransition(StateStatus::Entering, &state);
-
     auto act = handler.getActiveState();
 
-    if (act && act->is(StateStatus::Exiting) == false)
-        handler.stageTransition(StateStatus::Exiting, act);
+    handler.setNextState(&state);
+    
+    handler.beginTransitionQueue();
 
+    if (act && act->is(StateStatus::Exiting) == false)
+        handler.queueTransition(StateStatus::Exiting, act);
+
+    handler.queueTransition(StateStatus::Entering, &state);
+    handler.endTransitionQueue(&state);
+    
     if (immediate)
         handler.execute();
 }
@@ -58,7 +57,6 @@ void FiniteStateMachine<TContext>::transitionTo(FiniteStateMachine<TContext>::St
 template<class TContext>
 void FiniteStateMachine<TContext>::update()
 {
+    handler.queueTransition(StateStatus::Updating, handler.getNextState());
     handler.execute();
-
-    handler.stageTransition(StateStatus::Updating, handler.getCurrentState());
 }

--- a/src/HierarchicalStateMachine.hpp
+++ b/src/HierarchicalStateMachine.hpp
@@ -6,10 +6,6 @@
 #define HSM_STACK_DEPTH 10
 #endif
 
-#ifndef HSM_TRANSITION_STACK_SIZE
-#define HSM_TRANSITION_STACK_SIZE (HSM_STACK_DEPTH * 3)
-#endif
-
 template<class TContext>
 class HierarchicalStateMachine
 {
@@ -29,7 +25,6 @@ public:
 
     }
 
-
     bool isInState(State& state) const
     {
         return handler.isInState(state);
@@ -39,11 +34,13 @@ public:
     void transitionTo(State& state, bool immediate = false);
 
 private:
-    static State* findLeastCommonAncestorState(State* const s1, State* const s2);
-    void stageTransitionTopDown(State* state, State* const ancestor, StateStatus status);
-    void stageTransitionBottomUp(State* state, State* const ancestor, StateStatus status);
+    static constexpr uint8_t QUEUE_SIZE = (HSM_STACK_DEPTH * 3) + 1;
 
-    StateMachineHandler<TContext, HSM_TRANSITION_STACK_SIZE> handler;
+    static State* findLeastCommonAncestorState(State* const s1, State* const s2);
+    void queueTransitionTopDown(State* state, State* ancestor, StateStatus status);
+    void queueTransitionBottomUp(State* state, State* ancestor, StateStatus status);
+
+    StateMachineHandler<TContext, QUEUE_SIZE + 1> handler;
 };
 
 template<class TContext>
@@ -76,7 +73,7 @@ typename HierarchicalStateMachine<TContext>::State* HierarchicalStateMachine<TCo
 }
 
 template<class TContext>
-void HierarchicalStateMachine<TContext>::stageTransitionTopDown(HierarchicalStateMachine<TContext>::State* state, HierarchicalStateMachine<TContext>::State* const ancestor, StateStatus status)
+void HierarchicalStateMachine<TContext>::queueTransitionTopDown(HierarchicalStateMachine<TContext>::State* state, HierarchicalStateMachine<TContext>::State* ancestor, StateStatus status)
 {
     State* stateStack[HSM_STACK_DEPTH];
     uint8_t stateStackTop = 0;
@@ -89,16 +86,16 @@ void HierarchicalStateMachine<TContext>::stageTransitionTopDown(HierarchicalStat
 
     while (stateStackTop > 0)
     {
-        handler.stageTransition(status, stateStack[--stateStackTop]);
+        handler.queueTransition(status, stateStack[--stateStackTop]);
     }
 }
 
 template<class TContext>
-void HierarchicalStateMachine<TContext>::stageTransitionBottomUp(HierarchicalStateMachine<TContext>::State* state, HierarchicalStateMachine<TContext>::State* const ancestor, StateStatus status)
+void HierarchicalStateMachine<TContext>::queueTransitionBottomUp(HierarchicalStateMachine<TContext>::State* state, HierarchicalStateMachine<TContext>::State* ancestor, StateStatus status)
 {
     while (state && state != ancestor)
     {
-        handler.stageTransition(status, state);
+        handler.queueTransition(status, state);
         state = state->parent;
     }
 }
@@ -106,15 +103,16 @@ void HierarchicalStateMachine<TContext>::stageTransitionBottomUp(HierarchicalSta
 template<class TContext>
 void HierarchicalStateMachine<TContext>::transitionTo(HierarchicalStateMachine<TContext>::State& state, bool immediate)
 {
-    handler.clearStagedTransitions();
-    
-    handler.stageTransition(&state);
-
     auto act = static_cast<HierarchicalStateMachine<TContext>::State*>(handler.getActiveState());
     auto lca = findLeastCommonAncestorState(act, &state);
 
-    stageTransitionBottomUp(&state, lca, StateStatus::Entering);
-    stageTransitionTopDown(act && act->is(StateStatus::Exiting) ? act->parent : act, lca, StateStatus::Exiting);
+    handler.setNextState(&state);
+    handler.beginTransitionQueue();
+    
+    queueTransitionTopDown(act && act->is(StateStatus::Exiting) ? act->parent : act, lca, StateStatus::Exiting);
+    queueTransitionBottomUp(&state, lca, StateStatus::Entering);
+
+    handler.endTransitionQueue(&state);
 
     if (immediate)
         handler.execute();
@@ -123,7 +121,7 @@ void HierarchicalStateMachine<TContext>::transitionTo(HierarchicalStateMachine<T
 template<class TContext>
 void HierarchicalStateMachine<TContext>::update()
 {
+    queueTransitionTopDown(static_cast<HierarchicalStateMachine<TContext>::State*>(handler.getNextState()), nullptr, StateStatus::Updating);
+    
     handler.execute();
-
-    stageTransitionBottomUp(static_cast<HierarchicalStateMachine<TContext>::State*>(handler.getCurrentState()), nullptr, StateStatus::Updating);
 }

--- a/src/StateBase.hpp
+++ b/src/StateBase.hpp
@@ -42,9 +42,9 @@ public:
     }
 
 protected:
-    StateBase(StateCallback<TContext> enter, StateCallback<TContext> update, StateCallback<TContext> exit) : status(static_cast<StateStatus>(0)), enterCallback(enter), updateCallback(update), exitCallback(exit)
+    constexpr StateBase(StateCallback<TContext> enter, StateCallback<TContext> update, StateCallback<TContext> exit) : status(static_cast<StateStatus>(0)), enterCallback(enter), updateCallback(update), exitCallback(exit)
     {
-        
+
     }
 
 private:

--- a/src/StateBase.hpp
+++ b/src/StateBase.hpp
@@ -42,7 +42,7 @@ public:
     }
 
 protected:
-    constexpr StateBase(StateCallback<TContext> enter, StateCallback<TContext> update, StateCallback<TContext> exit) : status(static_cast<StateStatus>(0)), enterCallback(enter), updateCallback(update), exitCallback(exit)
+    StateBase(StateCallback<TContext> enter, StateCallback<TContext> update, StateCallback<TContext> exit) : status(static_cast<StateStatus>(0)), enterCallback(enter), updateCallback(update), exitCallback(exit)
     {
 
     }

--- a/src/StateBase.hpp
+++ b/src/StateBase.hpp
@@ -42,9 +42,9 @@ public:
     }
 
 protected:
-    constexpr StateBase(StateCallback<TContext> enter, StateCallback<TContext> update, StateCallback<TContext> exit) : status(static_cast<StateStatus>(0)), enterCallback(enter), updateCallback(update), exitCallback(exit)
+    StateBase(StateCallback<TContext> enter, StateCallback<TContext> update, StateCallback<TContext> exit) : status(static_cast<StateStatus>(0)), enterCallback(enter), updateCallback(update), exitCallback(exit)
     {
-
+        
     }
 
 private:

--- a/src/StateMachineHandler.hpp
+++ b/src/StateMachineHandler.hpp
@@ -5,14 +5,14 @@ template<class TContext, uint8_t SZ>
 class StateMachineHandler
 {
 public:
-    explicit StateMachineHandler(TContext* context) : currentState(nullptr), activeState(nullptr), context(context), transitionStackTop(0), transitionStack{}
+    explicit StateMachineHandler(TContext* context) : currentState(nullptr), activeState(nullptr), nextState(nullptr), context(context), queueHead(0), queueTail(0), transitionOccurred(0), transitionQueue{}
     {
 
     }
 
-    StateBase<TContext>* getCurrentState() const
+    StateBase<TContext>* getNextState() const
     {
-        return currentState;
+        return nextState;
     }
 
     StateBase<TContext>* getActiveState() const
@@ -25,19 +25,25 @@ public:
         return currentState == &state;
     }
 
-    void stageTransition(StateBase<TContext>* const state)
+    void setNextState(StateBase<TContext>* state)
     {
-        stageTransition(static_cast<StateStatus>(0), currentState, state);
+        nextState = state;
     }
 
-    void stageTransition(StateStatus status, StateBase<TContext>* dst)
+    void queueTransition(StateStatus status, StateBase<TContext>* dst)
     {
-        stageTransition(status, activeState, dst);
+        queueTransition(status, activeState, dst);
     }
 
-    void clearStagedTransitions()
+    void endTransitionQueue(StateBase<TContext>* const state)
     {
-        transitionStackTop = 0;
+        queueTransition(static_cast<StateStatus>(0), currentState, state);
+    }
+
+    void beginTransitionQueue()
+    {
+        transitionOccurred = true;
+        queueHead = queueTail;
     }
 
     void execute();
@@ -50,28 +56,40 @@ private:
         StateBase<TContext>* dst;
     };
 
-    void stageTransition(StateStatus status, StateBase<TContext>*& src, StateBase<TContext>* dst)
-    {
-        if (transitionStackTop >= SZ)
-            return;
-
-        transitionStack[transitionStackTop++] = { status, &src, dst };
-    }
+    void queueTransition(StateStatus status, StateBase<TContext>*& src, StateBase<TContext>* dst);
 
     StateBase<TContext>* currentState;
     StateBase<TContext>* activeState;
+    StateBase<TContext>* nextState;
     TContext* const context;
 
-    uint8_t transitionStackTop;
-    Transition transitionStack[SZ];
+    uint8_t queueHead;
+    uint8_t queueTail;
+    bool transitionOccurred;
+    Transition transitionQueue[SZ];
 };
+
+template<class TContext, uint8_t SZ>
+void StateMachineHandler<TContext, SZ>::queueTransition(StateStatus status, StateBase<TContext>*& src, StateBase<TContext>* dst)
+{
+    auto nextQueueTail = (queueTail + 1) % SZ;
+
+    if (nexQueueTail != queueHead)
+    {
+        transitionQueue[queueTail] = { status, &src, dst };
+        queueTail = nextQueueTail;
+    }
+}
 
 template<class TContext, uint8_t SZ>
 void StateMachineHandler<TContext, SZ>::execute()
 {
-    while (transitionStackTop > 0)
+    transitionOccurred = false;
+
+    while (queueHead != queueTail && transitionOccurred == false)
     {
-        auto transition = transitionStack[--transitionStackTop];
+        auto transition = transitionQueue[queueHead];
+        queueHead = (queueHead + 1) % SZ;
         
         *transition.src = transition.dst;
 


### PR DESCRIPTION
  - changed data structure from stack to queue
  - updated order of queueing transitions
  - removed transition stack size macro on FSM and HSM
  - added a transition flag to stop handling next state transition in current loop