### PR TITLE
address #7

### DIFF
--- a/examples/FSM/FooContext.hpp
+++ b/examples/FSM/FooContext.hpp
@@ -9,7 +9,7 @@ struct FooContext
     static FState<FooContext> sCooldown;
 
     uint8_t count;
-    uint8_t elapsed;
+    unsigned long elapsed;
 
     FSM<FooContext>* fsm;
 };

--- a/examples/FSM/States/RunState.cpp
+++ b/examples/FSM/States/RunState.cpp
@@ -18,8 +18,10 @@ static void update(FooContext* const ctx)
 
     if (digitalRead(4) == LOW)
         ctx->fsm->transitionTo(FooContext::sOff);
-    else if (((ctx->count + 1) % 6) == 0)
+    else if (((ctx->count + 1) % 6) == 0){
+        ctx->count = 0;
         ctx->fsm->transitionTo(FooContext::sCooldown);
+    }
 }
 
 FState<FooContext> FooContext::sRun(enter, update, nullptr);

--- a/examples/HSM/FooContext.hpp
+++ b/examples/HSM/FooContext.hpp
@@ -10,8 +10,8 @@ struct FooContext
     static HState<FooContext> sCooldown;
 
     uint8_t count;
-    uint8_t current;
-    uint8_t elapsed;
+    unsigned long current;
+    unsigned long elapsed;
 
     HSM<FooContext, 5>* hsm;
 };

--- a/examples/HSM/States/RunState.cpp
+++ b/examples/HSM/States/RunState.cpp
@@ -13,8 +13,10 @@ static void update(FooContext* const ctx)
         ctx->count++;
     }
 
-    if (((ctx->count +1) % 6) == 0)
+    if (((ctx->count +1) % 6) == 0){
+        ctx->count = 0;
         ctx->transitionTo(FooContext::sCooldown);
+    }
 }
 
 HState<FooContext> FooContext::sRun(&FooContext::sOnGroup, enter, update, nullptr);


### PR DESCRIPTION
Arduino's `millis()` returns an `unsigned long` (see https://reference.arduino.cc/reference/en/language/functions/time/millis/). When stored in `elapsed` or `current` (`uint8_t`) this leads to the behavior described in #7.

Also, potentially the `ctx->count` might overflow at some point. Resetting it to 0 whenever the condition for the modulo operator is met, will avoid this.